### PR TITLE
add getting cert details from url into info command

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,11 @@ gossl key --bits 2048 --out private.key --withpub
 
 ### info
 `info` displays information about x509 certificate. Thanks [grantae](https://github.com/grantae) for great [certinfo](https://github.com/grantae/certinfo) tool which is used here.
+A file path or a valid URL is used to get details of the certificate.
 
 ```bash
 gossl info cert.pem
+gossl info https://www.google.com
 ```
 
 ### cert
@@ -145,4 +147,3 @@ gossl ssh-copy --pubkey /home/user/.ssh/id_rsa.pub --password passw@rd123 remote
 2. Add cert template format read from yaml file
 3. Add certificate converter command like DER to PEM etc.
 4. Add test for CertFromFile function at utils package
-5. Send http request and display certificate info with info command

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ A file path or a valid URL is used to get details of the certificate.
 
 ```bash
 gossl info cert.pem
-gossl info https://www.google.com
+gossl info --url google.com
 ```
 
 ### cert

--- a/commands/info/info.go
+++ b/commands/info/info.go
@@ -27,7 +27,7 @@ func Command() *cli.Command {
 		Name:        CmdInfo,
 		HelpName:    CmdInfo,
 		Action:      Action,
-		ArgsUsage:   `[cert file path or URL ]`,
+		ArgsUsage:   `[cert file path]`,
 		Usage:       `displays information about certificate.`,
 		Description: `Displays information about x509 certificate.`,
 		Flags:       Flags(),

--- a/commands/info/info.go
+++ b/commands/info/info.go
@@ -1,13 +1,11 @@
 package info
 
 import (
+	"crypto/tls"
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"io"
-	"io/ioutil"
 	"log"
-	"net/http"
 	"net/url"
 	"os"
 
@@ -21,6 +19,7 @@ const (
 	CmdInfo = "info"
 
 	flagOut = "out"
+	flagURL = "url"
 )
 
 func Command() *cli.Command {
@@ -43,16 +42,16 @@ func Flags() []cli.Flag {
 			DefaultText: "eg, ./cert.pem",
 			Required:    false,
 		},
+		&cli.StringFlag{
+			Name:        flagURL,
+			Usage:       "URL to get certificate details from (optional)",
+			DefaultText: "eg, google.com",
+			Required:    false,
+		},
 	}
 }
 
 func Action(c *cli.Context) error {
-	if c.Args().Len() == 0 {
-		err := errors.New("cert file or URL argument is not found")
-		log.Printf("%v", err)
-		return err
-	}
-
 	// Set output
 	output := os.Stdout
 	outputFilePath := output.Name()
@@ -60,11 +59,37 @@ func Action(c *cli.Context) error {
 		outputFilePath = c.String(flagOut)
 	}
 
-	// Get certificate from file or URL
-	certPath := c.Args().First()
-	cert, err := readX509FromFileOrURL(certPath)
-	if err != nil {
-		return err
+	var (
+		err  error
+		cert *x509.Certificate
+	)
+
+	if c.IsSet(flagURL) {
+		u := c.String(flagURL)
+		cert, err = readX509FromDomain(u)
+		if err != nil {
+			log.Printf("failed to get cert details from %q: %v", u, err)
+			return err
+		}
+	} else {
+		if c.Args().Len() == 0 {
+			err := errors.New("cert file argument is not found")
+			log.Printf("%v", err)
+			return err
+		}
+
+		// Get certificate from file
+		path := c.Args().First()
+		if err != nil {
+			return err
+		}
+
+		// Read from file
+		cert, err = utils.CertFromFile(path)
+		if err != nil {
+			log.Printf("failed to get cert from file %q: %v", path, err)
+			return err
+		}
 	}
 
 	// Print the certificate
@@ -82,34 +107,40 @@ func Action(c *cli.Context) error {
 	return nil
 }
 
-func readX509FromFileOrURL(path string) (*x509.Certificate, error) {
-	// Check if given URL is a valid URI
-	if u, err := url.ParseRequestURI(path); err == nil {
-		resp, err := http.Get(u.String())
+func readX509FromDomain(uri string) (*x509.Certificate, error) {
+	u, err := url.Parse(uri)
+	if err != nil {
+		return nil, err
+	}
+
+	// if no schema is used, parse with default scheme //
+	// to get the host name
+	if u.Host == "" {
+		uri = "//" + uri
+		u, err = url.Parse(uri)
 		if err != nil {
 			return nil, err
 		}
-		defer resp.Body.Close()
-		// We don't need body but it must be read to EOF
-		// before closing.
-		io.Copy(ioutil.Discard, resp.Body)
-
-		// Get certificate returned from the server
-		if resp.TLS != nil {
-			certs := resp.TLS.PeerCertificates
-			if len(certs) > 0 {
-				return certs[0], nil
-			}
-		}
-
-		return nil, fmt.Errorf("no certificate returned from %q", u.String())
 	}
 
-	// Read from file
-	cert, err := utils.CertFromFile(path)
+	uri = u.Host
+	if u.Port() == "" {
+		uri += ":443"
+	}
+
+	conn, err := tls.Dial("tcp", uri, &tls.Config{})
 	if err != nil {
-		return nil, fmt.Errorf("failed to get cert from file %q: %v", path, err)
+		return nil, err
 	}
 
-	return cert, nil
+	defer conn.Close()
+
+	// Get certificates returned from the server
+	certs := conn.ConnectionState().PeerCertificates
+	if len(certs) > 0 {
+		// Return the first certificate
+		return certs[0], nil
+	}
+
+	return nil, fmt.Errorf("no certificate returned from %q", u.String())
 }

--- a/commands/info/info_test.go
+++ b/commands/info/info_test.go
@@ -72,6 +72,12 @@ func TestInfo(t *testing.T) {
 			out:       "/wrong-out",
 			shouldErr: true,
 		},
+		{
+			name:      "valid URL with output",
+			arg:       argURL,
+			out:       outFilePath,
+			shouldErr: false,
+		},
 	}
 
 	for _, tC := range testCases {

--- a/commands/info/info_test.go
+++ b/commands/info/info_test.go
@@ -25,13 +25,17 @@ func TestInfo(t *testing.T) {
 	outFilePath := filepath.Join(tempDir, "test-file-*")
 
 	const (
-		argFile = "../../testdata/server-cert.pem"
-		argURL  = "https://www.google.com"
+		argFile               = "../../testdata/server-cert.pem"
+		flagURL               = "google.com"
+		flagURLwithScheme     = "https://google.com"
+		flagURLwithPort       = "google.com:443"
+		flagURLwithSchemePort = "https://google.com:443"
 	)
 
 	testCases := []struct {
 		name      string
 		arg       string
+		url       string
 		out       string
 		shouldErr bool
 	}{
@@ -63,19 +67,34 @@ func TestInfo(t *testing.T) {
 		},
 		{
 			name:      "valid URL",
-			arg:       argURL,
+			url:       flagURL,
 			shouldErr: false,
 		},
 		{
 			name:      "wrong output with url",
-			arg:       argURL,
+			url:       flagURL,
 			out:       "/wrong-out",
 			shouldErr: true,
 		},
 		{
 			name:      "valid URL with output",
-			arg:       argURL,
+			url:       flagURL,
 			out:       outFilePath,
+			shouldErr: false,
+		},
+		{
+			name:      "valid URL with scheme",
+			url:       flagURLwithScheme,
+			shouldErr: false,
+		},
+		{
+			name:      "valid URL with port",
+			url:       flagURLwithPort,
+			shouldErr: false,
+		},
+		{
+			name:      "valid URL with scheme and port",
+			url:       flagURLwithSchemePort,
 			shouldErr: false,
 		},
 	}
@@ -85,6 +104,9 @@ func TestInfo(t *testing.T) {
 			testArgs := []string{execName, info.CmdInfo}
 			if tC.out != "" {
 				testArgs = append(testArgs, "--out", tC.out)
+			}
+			if tC.url != "" {
+				testArgs = append(testArgs, "--url", tC.url)
 			}
 			if tC.arg != "" {
 				testArgs = append(testArgs, tC.arg)

--- a/commands/info/info_test.go
+++ b/commands/info/info_test.go
@@ -24,7 +24,10 @@ func TestInfo(t *testing.T) {
 	tempDir := t.TempDir()
 	outFilePath := filepath.Join(tempDir, "test-file-*")
 
-	arg := "../../testdata/server-cert.pem"
+	const (
+		argFile = "../../testdata/server-cert.pem"
+		argURL  = "https://www.google.com"
+	)
 
 	testCases := []struct {
 		name      string
@@ -33,8 +36,8 @@ func TestInfo(t *testing.T) {
 		shouldErr bool
 	}{
 		{
-			name:      "valid cert",
-			arg:       arg,
+			name:      "valid cert file",
+			arg:       argFile,
 			shouldErr: false,
 		},
 		{
@@ -42,26 +45,32 @@ func TestInfo(t *testing.T) {
 			shouldErr: true,
 		},
 		{
-			name:      "wrong cert",
+			name:      "wrong cert file or invalid URL",
 			arg:       "wrong-arg",
 			shouldErr: true,
 		},
 		{
-			name:      "valid cert",
-			arg:       arg,
+			name:      "valid cert file with output",
+			arg:       argFile,
 			out:       outFilePath,
 			shouldErr: false,
 		},
 		{
 			name:      "wrong output",
-			arg:       arg,
+			arg:       argFile,
 			out:       "/wrong-out",
 			shouldErr: true,
 		},
 		{
 			name:      "valid URL",
-			arg:       "https://www.google.com",
+			arg:       argURL,
 			shouldErr: false,
+		},
+		{
+			name:      "wrong output with url",
+			arg:       argURL,
+			out:       "/wrong-out",
+			shouldErr: true,
 		},
 	}
 

--- a/commands/info/info_test.go
+++ b/commands/info/info_test.go
@@ -24,9 +24,7 @@ func TestInfo(t *testing.T) {
 	tempDir := t.TempDir()
 	outFilePath := filepath.Join(tempDir, "test-file-*")
 
-	var (
-		arg = "../../testdata/server-cert.pem"
-	)
+	arg := "../../testdata/server-cert.pem"
 
 	testCases := []struct {
 		name      string
@@ -59,6 +57,11 @@ func TestInfo(t *testing.T) {
 			arg:       arg,
 			out:       "/wrong-out",
 			shouldErr: true,
+		},
+		{
+			name:      "valid URL",
+			arg:       "https://www.google.com",
+			shouldErr: false,
 		},
 	}
 


### PR DESCRIPTION
I added getting certificate details from given URL to `info` command.

I used the same argument which can be replaced with the file path.
```bash
gossl info https://www.google.com
```
or
```bash
gossl info cert.pem
```
In both ways, output file can be used to write details.

If adding a URL flag is better, I can convert it too.